### PR TITLE
Fix Markdown link check

### DIFF
--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -2,8 +2,6 @@ name: Check Markdown links
 
 on:
   push:
-    branches:
-      - main
   pull_request:
   schedule:
     - cron: '15 0,12 * * *'


### PR DESCRIPTION
Same bug as https://github.com/EliahKagan/vennjs/pull/2. Same fix.

It was set to run on the "main" branch. This repo has "master" instead.

I could change the name in markdown-links.yml, but I've just changed it to run on any branch instead.